### PR TITLE
Defer guessing the key until it is actually needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ however you like:
 
 ### Key Signatures
 
-You can see the current key signature of the text through `currentKey`.
+You can see the current key signature of the text through `getKey()`.
 
 ```javascript
-> Transposer.transpose('C  G').currentKey
+> Transposer.transpose('C  G').getKey()
 KeySignature {
   _description: 'C',
   _ordinal: 0,
@@ -117,7 +117,7 @@ KeySignature {
   rank: 0,
   _propName: 'C' }
 
-> Transposer.transpose('C  G').up(4).currentKey
+> Transposer.transpose('C  G').up(4).getKey()
 KeySignature {
   _description: 'E',
   _ordinal: 4,

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,9 @@ function _transpose(tokens: any[][],
 
   const noteMap = transpositionMap(fromKey, toKey);
 
-  return tokens.map(line => line.map(token => token instanceof Chord ? new Chord(noteMap[token.root], token.suffix, noteMap[token.bass]) : token));
+  return tokens.map(line =>
+      line.map(token =>
+          token instanceof Chord ? new Chord(noteMap[token.root], token.suffix, noteMap[token.bass]) : token));
 }
 
 /**

--- a/test/test.ts
+++ b/test/test.ts
@@ -136,11 +136,11 @@ describe('Transposer', () => {
 
   it ("The resulting keys are correct", () => {
     for (let i = 0; i < 12; i++) {
-      expect(transpose('C').up(i).currentKey.majorKey)
+      expect(transpose('C').up(i).getKey().majorKey)
         .to.equal(KEYS[i]);
     }
     for (let i = 0; i < 12; i++) {
-      expect(transpose('C').toKey(KEYS[i]).currentKey.majorKey)
+      expect(transpose('C').toKey(KEYS[i]).getKey().majorKey)
         .to.equal(KEYS[i]);
     }
   });
@@ -225,5 +225,10 @@ describe('Transposer', () => {
   it ("Handles sequence of chords separated by dash", () => {
     expect(transpose("A-E-F#m-D").up(1).toString())
       .to.equal("Bb-F-Gm-Eb");
+  });
+
+  it ("Should not try to guess the key if an explicit key is provided", () => {
+    expect(transpose("G#").fromKey("C#m").toKey("Cm").toString())
+      .to.equal("G")
   });
 });


### PR DESCRIPTION
This allows the user to explicitly set the song key and prevents
the transposer to always try to guess the song key during construction.

A use case where this would fail would be the sequence `G#` in the key
of `C#m`, because `G#` is considered an invalid chord on its own.

Fixes #6