### PR TITLE
Add support for more sharp key signatures

### DIFF
--- a/dist/KeySignatures.js
+++ b/dist/KeySignatures.js
@@ -47,6 +47,11 @@ var KeySignatureEnum = /** @class */ (function (_super) {
         _this.A = new KeySignature('A', 'F#m', KeyType.SHARP, 9);
         _this.Bb = new KeySignature('Bb', 'Gm', KeyType.FLAT, 10);
         _this.B = new KeySignature('B', 'G#m', KeyType.SHARP, 11);
+        _this.Csharp = new KeySignature('C#', 'Bbm', KeyType.SHARP, 12);
+        _this.Dsharp = new KeySignature('D#', 'Cm', KeyType.SHARP, 13);
+        _this.Esharp = new KeySignature('E#', 'Dm', KeyType.SHARP, 14);
+        _this.Gsharp = new KeySignature('G#', 'Fm', KeyType.SHARP, 15);
+        _this.Asharp = new KeySignature('A#', 'Gm', KeyType.SHARP, 16);
         _this.initEnum('KeySignature');
         return _this;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,7 @@ var Transposer = /** @class */ (function () {
     Transposer.transpose = function (text) {
         return new Transposer(text);
     };
-    /** Guesses the key of the text. Currently just takes the first chord. */
+    /** Get the key of the text. If not explicitly set, it will be guessed from the first chord. */
     Transposer.prototype.getKey = function () {
         if (this.currentKey) {
             return this.currentKey;
@@ -165,7 +165,11 @@ function parse(text, threshold) {
  */
 function _transpose(tokens, fromKey, toKey) {
     var noteMap = transpositionMap(fromKey, toKey);
-    return tokens.map(function (line) { return line.map(function (token) { return token instanceof Chord ? new Chord(noteMap[token.root], token.suffix, noteMap[token.bass]) : token; }); });
+    return tokens.map(function (line) {
+        return line.map(function (token) {
+            return token instanceof Chord ? new Chord(noteMap[token.root], token.suffix, noteMap[token.bass]) : token;
+        });
+    });
 }
 /**
  * Given the current key and the number of semitones to transpose, returns a

--- a/src/KeySignatures.ts
+++ b/src/KeySignatures.ts
@@ -52,6 +52,21 @@ class KeySignatureEnum extends Enum<KeySignature> {
   B: KeySignature =
     new KeySignature('B', 'G#m', KeyType.SHARP, 11);
 
+  Csharp: KeySignature =
+    new KeySignature('C#', 'Bbm', KeyType.SHARP, 12);
+
+  Dsharp: KeySignature =
+    new KeySignature('D#', 'Cm', KeyType.SHARP, 13);
+
+  Esharp: KeySignature =
+    new KeySignature('E#', 'Dm', KeyType.SHARP, 14);
+
+  Gsharp: KeySignature =
+    new KeySignature('G#', 'Fm', KeyType.SHARP, 15);
+
+  Asharp: KeySignature =
+    new KeySignature('A#', 'Gm', KeyType.SHARP, 16);
+
   constructor() {
     super();
     this.initEnum('KeySignature');

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,8 +181,8 @@ function _transpose(tokens: any[][],
   const noteMap = transpositionMap(fromKey, toKey);
 
   return tokens.map(line =>
-      line.map(token =>
-          token instanceof Chord ? new Chord(noteMap[token.root], token.suffix, noteMap[token.bass]) : token));
+    line.map(token =>
+      token instanceof Chord ? new Chord(noteMap[token.root], token.suffix, noteMap[token.bass]) : token));
 }
 
 /**

--- a/test/test.ts
+++ b/test/test.ts
@@ -157,8 +157,6 @@ describe('Transposer', () => {
   });
 
   it ("An error should be thrown for invalid key signature", () => {
-    expect(() => { return transpose(C_MAJOR).toKey('D#').toString(); })
-      .to.throw(Error, 'not a valid key signature');
     expect(() => { return transpose(C_MAJOR).toKey('blah').toString(); })
       .to.throw(Error, 'blah is not a valid key signature.');
   });


### PR DESCRIPTION
Fixes #8 

Add support for more keys in `#` 

I'm able to write some tests if we think it's needed.  I removed 1 of them since `D#` is now a valid key.